### PR TITLE
Add Kinobi IDL

### DIFF
--- a/program/idl.json
+++ b/program/idl.json
@@ -139,7 +139,7 @@
           "During the first call to `store`, no signers will be required.",
           "Subsequent calls may add new required signers, but cannot remove any previously configured signers."
         ],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "omitted"
       }
     ],
     "definedTypes": [],

--- a/program/idl.json
+++ b/program/idl.json
@@ -134,10 +134,9 @@
         ],
         "name": "store",
         "docs": [
-          "Initializes or updates the config account.",
-          "Additional signers may be required to modify the config data.",
-          "During the first call to `store`, no signers will be required.",
-          "Subsequent calls may add new required signers, but cannot remove any previously configured signers."
+          "Stores keys and data in a config account.",
+          "Keys can be marked as signer or non-signer.",
+          "Only non-signer keys and data can be updated. Signer keys are immutable."
         ],
         "optionalAccountStrategy": "omitted"
       }

--- a/program/idl.json
+++ b/program/idl.json
@@ -39,7 +39,18 @@
                   }
                 }
               },
-              "docs": []
+              "docs": [
+                "List of pubkeys stored in the config account,",
+                "and whether each pubkey needs to sign subsequent calls to `store`."
+              ]
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "data",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "docs": ["Arbitrary data to store in the config account."]
             }
           ]
         },
@@ -57,7 +68,11 @@
             "isWritable": true,
             "isSigner": "either",
             "isOptional": false,
-            "docs": []
+            "docs": [
+              "The config account to be modified.",
+              "Must sign during the first call to `store` to initialize the account,",
+              "or if no signers are configured in the config data."
+            ]
           }
         ],
         "arguments": [
@@ -91,7 +106,19 @@
                 }
               }
             },
-            "docs": []
+            "docs": [
+              "List of pubkeys to store in the config account,",
+              "and whether each pubkey needs to sign subsequent calls to `store`.",
+              "Non-signer pubkeys do not need to be passed to the program as accounts."
+            ]
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "data",
+            "type": {
+              "kind": "bytesTypeNode"
+            },
+            "docs": ["Arbitrary data to store in the config account."]
           }
         ],
         "remainingAccounts": [
@@ -105,8 +132,13 @@
             "isSigner": true
           }
         ],
-        "name": "initialize",
-        "docs": [],
+        "name": "store",
+        "docs": [
+          "Initializes or updates the config account.",
+          "Additional signers may be required to modify the config data.",
+          "During the first call to `store`, no signers will be required.",
+          "Subsequent calls may add new required signers, but cannot remove any previously configured signers."
+        ],
         "optionalAccountStrategy": "programId"
       }
     ],

--- a/program/idl.json
+++ b/program/idl.json
@@ -1,0 +1,124 @@
+{
+  "kind": "rootNode",
+  "program": {
+    "kind": "programNode",
+    "pdas": [],
+    "accounts": [
+      {
+        "kind": "accountNode",
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "keys",
+              "type": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "tupleTypeNode",
+                  "items": [
+                    {
+                      "kind": "publicKeyTypeNode"
+                    },
+                    {
+                      "kind": "booleanTypeNode",
+                      "size": {
+                        "kind": "numberTypeNode",
+                        "format": "u8",
+                        "endian": "le"
+                      }
+                    }
+                  ]
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "shortU16",
+                    "endian": "le"
+                  }
+                }
+              },
+              "docs": []
+            }
+          ]
+        },
+        "name": "config",
+        "docs": []
+      }
+    ],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "accounts": [
+          {
+            "kind": "instructionAccountNode",
+            "name": "configAccount",
+            "isWritable": true,
+            "isSigner": "either",
+            "isOptional": false,
+            "docs": []
+          }
+        ],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "keys",
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "tupleTypeNode",
+                "items": [
+                  {
+                    "kind": "publicKeyTypeNode"
+                  },
+                  {
+                    "kind": "booleanTypeNode",
+                    "size": {
+                      "kind": "numberTypeNode",
+                      "format": "u8",
+                      "endian": "le"
+                    }
+                  }
+                ]
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "shortU16",
+                  "endian": "le"
+                }
+              }
+            },
+            "docs": []
+          }
+        ],
+        "remainingAccounts": [
+          {
+            "kind": "instructionRemainingAccountsNode",
+            "value": {
+              "kind": "argumentValueNode",
+              "name": "signers"
+            },
+            "isOptional": true,
+            "isSigner": true
+          }
+        ],
+        "name": "initialize",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "name": "config",
+    "prefix": "",
+    "publicKey": "Config1111111111111111111111111111111111111",
+    "version": "0.0.1",
+    "origin": "shank"
+  },
+  "additionalPrograms": [],
+  "standard": "kinobi",
+  "version": "0.19.0"
+}


### PR DESCRIPTION
This PR uses the Kinobi IDL standard to describe the Config program.

Notice it uses features such as `shortU16` numbers, `"either"` signers and remaining account nodes which are not supported by the Anchor IDL standard.