### PR TITLE
Use proper program id in program tests

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -6,7 +6,4 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
-// [Core BPF]: TODO: Program-test will not overwrite existing built-ins.
-// See https://github.com/solana-labs/solana/pull/35233.
-// solana_program::declare_id!("Config1111111111111111111111111111111111111");
-solana_program::declare_id!("J333MuXPTwcHvibaTNMW32FZj6EHuowCnAHvvP99vnKv");
+solana_program::declare_id!("Config1111111111111111111111111111111111111");

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -43,12 +43,8 @@ impl ConfigState for MyConfig {
 
 async fn setup_test_context() -> ProgramTestContext {
     let mut program_test = ProgramTest::default();
-    program_test.prefer_bpf(true);
-    program_test.add_program(
-        "solana_config_program",
-        solana_config_program::id(),
-        processor!(solana_config_program::processor::process),
-    );
+    program_test
+        .add_upgradeable_program_to_genesis("solana_config_program", &solana_config_program::id());
     program_test.start_with_context().await
 }
 


### PR DESCRIPTION
#### Problem
In the first BPF implementation of the program, we had to temporarily use an
arbitrary program ID in order to successfully test the program as a BPF
program.

Now that 2.0 is released, we can use `add_upgradeable_program_to_genesis`
to add a Core BPF program to the Bank and prevent it from being overwritten
by its original builtin counterpart.

#### Summary of Changes
Update the tests to use this new method, and the proper ID for the program!