### PR TITLE
program: safe deserialize config keys

### DIFF
--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,44 @@
+#### Compute Units: 2024-10-31 17:22:37.667457 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| config_small_init_0_keys | 584 | +3 |
+| config_small_init_1_keys | 1215 | +11 |
+| config_small_init_5_keys | 2834 | +35 |
+| config_small_init_10_keys | 4904 | +65 |
+| config_small_init_25_keys | 11746 | +155 |
+| config_small_init_37_keys | 16749 | +227 |
+| config_small_store_0_keys | 584 | +3 |
+| config_small_store_1_keys | 1469 | +11 |
+| config_small_store_5_keys | 4004 | +35 |
+| config_small_store_10_keys | 7219 | +65 |
+| config_small_store_25_keys | 17496 | +155 |
+| config_small_store_37_keys | 25247 | +227 |
+| config_medium_init_0_keys | 575 | +3 |
+| config_medium_init_1_keys | 1162 | +11 |
+| config_medium_init_5_keys | 2834 | +35 |
+| config_medium_init_10_keys | 4904 | +65 |
+| config_medium_init_25_keys | 11746 | +155 |
+| config_medium_init_37_keys | 16749 | +227 |
+| config_medium_store_0_keys | 575 | +3 |
+| config_medium_store_1_keys | 1416 | +11 |
+| config_medium_store_5_keys | 4004 | +35 |
+| config_medium_store_10_keys | 7219 | +65 |
+| config_medium_store_25_keys | 17496 | +155 |
+| config_medium_store_37_keys | 25247 | +227 |
+| config_large_init_0_keys | 696 | +3 |
+| config_large_init_1_keys | 1283 | +11 |
+| config_large_init_5_keys | 2955 | +35 |
+| config_large_init_10_keys | 5026 | +65 |
+| config_large_init_25_keys | 11870 | +155 |
+| config_large_init_37_keys | 16874 | +227 |
+| config_large_store_0_keys | 696 | +3 |
+| config_large_store_1_keys | 1537 | +11 |
+| config_large_store_5_keys | 4125 | +35 |
+| config_large_store_10_keys | 7341 | +65 |
+| config_large_store_25_keys | 17620 | +155 |
+| config_large_store_37_keys | 25372 | +227 |
+
 #### Compute Units: 2024-10-23 12:46:27.264402 UTC
 
 | Name | CUs | Delta |

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -83,7 +83,7 @@ fn test_process_create_ok() {
         &[(config, config_account)],
         &[
             Check::success(),
-            Check::compute_units(581),
+            Check::compute_units(584),
             Check::account(&config)
                 .data(
                     &bincode::serialize(&(ConfigKeys { keys: vec![] }, MyConfig::default()))
@@ -111,7 +111,7 @@ fn test_process_store_ok() {
         &[(config, config_account)],
         &[
             Check::success(),
-            Check::compute_units(581),
+            Check::compute_units(584),
             Check::account(&config)
                 .data(&bincode::serialize(&(ConfigKeys { keys }, my_config)).unwrap())
                 .build(),
@@ -186,7 +186,7 @@ fn test_process_store_with_additional_signers() {
         ],
         &[
             Check::success(),
-            Check::compute_units(3_228),
+            Check::compute_units(3_253),
             Check::account(&config)
                 .data(&bincode::serialize(&(ConfigKeys { keys }, my_config)).unwrap())
                 .build(),
@@ -285,7 +285,7 @@ fn test_config_updates() {
             (signer0, AccountSharedData::default()),
             (signer1, AccountSharedData::default()),
         ],
-        &[Check::success(), Check::compute_units(3_228)],
+        &[Check::success(), Check::compute_units(3_253)],
     );
 
     // Use this for next invoke.
@@ -303,7 +303,7 @@ fn test_config_updates() {
         ],
         &[
             Check::success(),
-            Check::compute_units(3_229),
+            Check::compute_units(3_254),
             Check::account(&config)
                 .data(&bincode::serialize(&(ConfigKeys { keys }, new_config)).unwrap())
                 .build(),
@@ -399,7 +399,7 @@ fn test_config_update_contains_duplicates_fails() {
             (signer0, AccountSharedData::default()),
             (signer1, AccountSharedData::default()),
         ],
-        &[Check::success(), Check::compute_units(3_228)],
+        &[Check::success(), Check::compute_units(3_253)],
     );
 
     // Attempt update with duplicate signer inputs.
@@ -443,7 +443,7 @@ fn test_config_updates_requiring_config() {
         ],
         &[
             Check::success(),
-            Check::compute_units(3_324),
+            Check::compute_units(3_352),
             Check::account(&config)
                 .data(&bincode::serialize(&(ConfigKeys { keys: keys.clone() }, my_config)).unwrap())
                 .build(),
@@ -464,7 +464,7 @@ fn test_config_updates_requiring_config() {
         ],
         &[
             Check::success(),
-            Check::compute_units(3_324),
+            Check::compute_units(3_352),
             Check::account(&config)
                 .data(&bincode::serialize(&(ConfigKeys { keys }, new_config)).unwrap())
                 .build(),
@@ -558,7 +558,7 @@ fn test_maximum_keys_input() {
     let result = mollusk.process_and_validate_instruction(
         &instruction,
         &[(config, config_account)],
-        &[Check::success(), Check::compute_units(25_020)],
+        &[Check::success(), Check::compute_units(25_247)],
     );
 
     // Use this for next invoke.
@@ -571,7 +571,7 @@ fn test_maximum_keys_input() {
     let result = mollusk.process_and_validate_instruction(
         &instruction,
         &[(config, updated_config_account)],
-        &[Check::success(), Check::compute_units(25_020)],
+        &[Check::success(), Check::compute_units(25_247)],
     );
 
     // Use this for next invoke.


### PR DESCRIPTION
#### Problem
Working with the Firedancer conformance suite revealed a relatively inconsequential control flow mismatch between the BPF version of the Config program and its original builtin version.

The `limited_deserialize` function is designed to stop deserialization at some input buffer length cap, but it _does not_ limit memory allocations as a result of some deserialized vector length. In the case of `ConfigKeys`, a very large `ShortU16` length value could be provided to the program's input, forcing the deserialization step to allocate space for a massive vector of `(Pubkey, bool)`, exhausting the BPF program's heap.

The program would still fail, but the error would be different between the builtin and BPF versions. To ensure maximum backwards compatibility, and to give developers a more proper error code, the BPF program's deserialization needs an additional check for allocation size.

#### Summary of Changes
Add a check for the provided `ShortU16` vector length to the program's input deserialization, to catch any would-be large vector allocations before causing an OOM.