### PR TITLE
program: use counter to access accounts list

### DIFF
--- a/program/benches/compute_units.md
+++ b/program/benches/compute_units.md
@@ -1,3 +1,44 @@
+#### Compute Units: 2024-11-01 15:31:11.543055 UTC
+
+| Name | CUs | Delta |
+|------|------|-------|
+| config_small_init_0_keys | 580 | -4 |
+| config_small_init_1_keys | 1211 | -4 |
+| config_small_init_5_keys | 2830 | -4 |
+| config_small_init_10_keys | 4900 | -4 |
+| config_small_init_25_keys | 11742 | -4 |
+| config_small_init_37_keys | 16745 | -4 |
+| config_small_store_0_keys | 580 | -4 |
+| config_small_store_1_keys | 1465 | -4 |
+| config_small_store_5_keys | 4000 | -4 |
+| config_small_store_10_keys | 7215 | -4 |
+| config_small_store_25_keys | 17492 | -4 |
+| config_small_store_37_keys | 25243 | -4 |
+| config_medium_init_0_keys | 571 | -4 |
+| config_medium_init_1_keys | 1158 | -4 |
+| config_medium_init_5_keys | 2830 | -4 |
+| config_medium_init_10_keys | 4900 | -4 |
+| config_medium_init_25_keys | 11742 | -4 |
+| config_medium_init_37_keys | 16745 | -4 |
+| config_medium_store_0_keys | 571 | -4 |
+| config_medium_store_1_keys | 1412 | -4 |
+| config_medium_store_5_keys | 4000 | -4 |
+| config_medium_store_10_keys | 7215 | -4 |
+| config_medium_store_25_keys | 17492 | -4 |
+| config_medium_store_37_keys | 25243 | -4 |
+| config_large_init_0_keys | 692 | -4 |
+| config_large_init_1_keys | 1279 | -4 |
+| config_large_init_5_keys | 2951 | -4 |
+| config_large_init_10_keys | 5022 | -4 |
+| config_large_init_25_keys | 11866 | -4 |
+| config_large_init_37_keys | 16870 | -4 |
+| config_large_store_0_keys | 692 | -4 |
+| config_large_store_1_keys | 1533 | -4 |
+| config_large_store_5_keys | 4121 | -4 |
+| config_large_store_10_keys | 7337 | -4 |
+| config_large_store_25_keys | 17616 | -4 |
+| config_large_store_37_keys | 25368 | -4 |
+
 #### Compute Units: 2024-10-31 17:22:37.667457 UTC
 
 | Name | CUs | Delta |


### PR DESCRIPTION
#### Problem
When initializing a config account, the config account is expected to be a signer. However, if it's also included in the signer list as a required signer, the loop where signer keys are checked will fail, telling the user that the account is missing. This failure case also arises when _updating_ a config account, and attempting to declare that the config account must be a signer for updates.

The account isn't actually missing, it's just the fact that the `if signer != config_account_key` is being evaluated _after_ the counter is advanced, so the rest of the loop is off by one.
https://github.com/anza-xyz/agave/blob/d9c24ed5837407aa411fbb7cc881c4a1a9757f5e/programs/config/src/config_processor.rs#L61-L72

In the BPF version, we properly handle this case by only advancing the `accounts_iter` when the list of accounts is actually accessed.

In my opinion, this seems like a bug with the builtin implementation, not the BPF version. It's possible that maybe the program isn't designed to allow you to include the config account as a required signer, but that seems like an unnecessary constraint.