### PR TITLE
interface: Add `get_config_data` helper to break circular deps

### DIFF
--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -14,3 +14,11 @@ pub struct ConfigKeys {
     #[cfg_attr(feature = "serde", serde(with = "short_vec"))]
     pub keys: Vec<(Pubkey, bool)>,
 }
+
+/// Utility for extracting the `ConfigKeys` data from the account data.
+#[cfg(feature = "bincode")]
+pub fn get_config_data(bytes: &[u8]) -> Result<&[u8], bincode::Error> {
+    bincode::deserialize::<ConfigKeys>(bytes)
+        .and_then(|keys| bincode::serialized_size(&keys))
+        .map(|offset| &bytes[offset as usize..])
+}


### PR DESCRIPTION
#### Problem

Agave is currently using auto-generated clients functions for the CLI, but the client libraries currently create a circular dependency with Agave crates through solana-client. We need to break the circular dependencies for our own sanity.

#### Summary of changes

Agave can be transitioned to `solana-config-interface`, but the interface is missing the `get_config_data` helper, so add that missing helper.