### PR TITLE
Rename config program to drop the solana prefix

### DIFF
--- a/clients/js/src/generated/instructions/store.ts
+++ b/clients/js/src/generated/instructions/store.ts
@@ -30,11 +30,11 @@ import {
     type WritableSignerAccount,
 } from '@solana/kit';
 import { getAccountMetaFactory, type ResolvedInstructionAccount } from '@solana/kit/program-client-core';
-import { SOLANA_CONFIG_PROGRAM_ADDRESS } from '../programs';
+import { CONFIG_PROGRAM_ADDRESS } from '../programs';
 import { getConfigKeysDecoder, getConfigKeysEncoder, type ConfigKeys, type ConfigKeysArgs } from '../types';
 
 export type StoreInstruction<
-    TProgram extends string = typeof SOLANA_CONFIG_PROGRAM_ADDRESS,
+    TProgram extends string = typeof CONFIG_PROGRAM_ADDRESS,
     TAccountConfigAccount extends string | AccountMeta<string> = string,
     TRemainingAccounts extends readonly AccountMeta<string>[] = [],
 > = Instruction<TProgram> &
@@ -100,7 +100,7 @@ export type StoreInput<TAccountConfigAccount extends string = string> = {
 
 export function getStoreInstruction<
     TAccountConfigAccount extends string,
-    TProgramAddress extends Address = typeof SOLANA_CONFIG_PROGRAM_ADDRESS,
+    TProgramAddress extends Address = typeof CONFIG_PROGRAM_ADDRESS,
 >(
     input: StoreInput<TAccountConfigAccount>,
     config?: { programAddress?: TProgramAddress },
@@ -111,7 +111,7 @@ export function getStoreInstruction<
         : TAccountConfigAccount
 > {
     // Program address.
-    const programAddress = config?.programAddress ?? SOLANA_CONFIG_PROGRAM_ADDRESS;
+    const programAddress = config?.programAddress ?? CONFIG_PROGRAM_ADDRESS;
 
     // Original accounts.
     const originalAccounts = { configAccount: { value: input.configAccount ?? null, isWritable: true } };
@@ -141,7 +141,7 @@ export function getStoreInstruction<
 }
 
 export type ParsedStoreInstruction<
-    TProgram extends string = typeof SOLANA_CONFIG_PROGRAM_ADDRESS,
+    TProgram extends string = typeof CONFIG_PROGRAM_ADDRESS,
     TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
 > = {
     programAddress: Address<TProgram>;

--- a/clients/js/src/generated/programs/config.ts
+++ b/clients/js/src/generated/programs/config.ts
@@ -24,41 +24,39 @@ import {
 import { getConfigCodec, type Config, type ConfigArgs } from '../accounts';
 import { getStoreInstruction, type ParsedStoreInstruction, type StoreInput } from '../instructions';
 
-export const SOLANA_CONFIG_PROGRAM_ADDRESS =
+export const CONFIG_PROGRAM_ADDRESS =
     'Config1111111111111111111111111111111111111' as Address<'Config1111111111111111111111111111111111111'>;
 
-export enum SolanaConfigAccount {
+export enum ConfigAccount {
     Config,
 }
 
-export enum SolanaConfigInstruction {
+export enum ConfigInstruction {
     Store,
 }
 
-export type ParsedSolanaConfigInstruction<TProgram extends string = 'Config1111111111111111111111111111111111111'> = {
-    instructionType: SolanaConfigInstruction.Store;
+export type ParsedConfigInstruction<TProgram extends string = 'Config1111111111111111111111111111111111111'> = {
+    instructionType: ConfigInstruction.Store;
 } & ParsedStoreInstruction<TProgram>;
 
-export type SolanaConfigPlugin = { accounts: SolanaConfigPluginAccounts; instructions: SolanaConfigPluginInstructions };
+export type ConfigPlugin = { accounts: ConfigPluginAccounts; instructions: ConfigPluginInstructions };
 
-export type SolanaConfigPluginAccounts = {
+export type ConfigPluginAccounts = {
     config: ReturnType<typeof getConfigCodec> & SelfFetchFunctions<ConfigArgs, Config>;
 };
 
-export type SolanaConfigPluginInstructions = {
+export type ConfigPluginInstructions = {
     store: (input: StoreInput) => ReturnType<typeof getStoreInstruction> & SelfPlanAndSendFunctions;
 };
 
-export type SolanaConfigPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> &
+export type ConfigPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> &
     ClientWithTransactionPlanning &
     ClientWithTransactionSending;
 
-export function solanaConfigProgram() {
-    return <T extends SolanaConfigPluginRequirements>(
-        client: T,
-    ): Omit<T, 'solanaConfig'> & { solanaConfig: SolanaConfigPlugin } => {
+export function configProgram() {
+    return <T extends ConfigPluginRequirements>(client: T): Omit<T, 'config'> & { config: ConfigPlugin } => {
         return extendClient(client, {
-            solanaConfig: <SolanaConfigPlugin>{
+            config: <ConfigPlugin>{
                 accounts: { config: addSelfFetchFunctions(client, getConfigCodec()) },
                 instructions: { store: input => addSelfPlanAndSendFunctions(client, getStoreInstruction(input)) },
             },

--- a/clients/js/src/generated/programs/index.ts
+++ b/clients/js/src/generated/programs/index.ts
@@ -6,4 +6,4 @@
  * @see https://github.com/codama-idl/codama
  */
 
-export * from './solanaConfig';
+export * from './config';

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -4,17 +4,9 @@ import { createClient, lamports } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
 import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
 
-import { SOLANA_CONFIG_PROGRAM_ADDRESS, solanaConfigProgram } from '../src';
+import { CONFIG_PROGRAM_ADDRESS, configProgram } from '../src';
 
-const SOLANA_CONFIG_BINARY_PATH = path.resolve(
-    __dirname,
-    '..',
-    '..',
-    '..',
-    'target',
-    'deploy',
-    'solana_config_program.so',
-);
+const CONFIG_BINARY_PATH = path.resolve(__dirname, '..', '..', '..', 'target', 'deploy', 'solana_config_program.so');
 
 export const createTestClient = () => {
     return createClient()
@@ -25,8 +17,8 @@ export const createTestClient = () => {
             // Load the config program into the LiteSVM instance from its
             // compiled `.so` file. This must run after the `litesvm()` plugin
             // so that `client.svm` is available.
-            client.svm.addProgramFromFile(SOLANA_CONFIG_PROGRAM_ADDRESS, SOLANA_CONFIG_BINARY_PATH);
+            client.svm.addProgramFromFile(CONFIG_PROGRAM_ADDRESS, CONFIG_BINARY_PATH);
             return client;
         })
-        .use(solanaConfigProgram());
+        .use(configProgram());
 };

--- a/clients/js/test/example.test.ts
+++ b/clients/js/test/example.test.ts
@@ -7,7 +7,7 @@ it('sets up a LiteSVM client with the config program', async () => {
     const client = await createTestClient();
 
     // Then the client exposes the config program plugin.
-    expect(client.solanaConfig).toBeDefined();
+    expect(client.config).toBeDefined();
 
     // And the payer was funded via LiteSVM.
     const { value: balance } = await client.rpc.getBalance(client.payer.address).send();

--- a/clients/rust/src/generated/instructions/store.rs
+++ b/clients/rust/src/generated/instructions/store.rs
@@ -41,7 +41,7 @@ impl Store {
         data.append(&mut args);
 
         solana_instruction::Instruction {
-            program_id: crate::SOLANA_CONFIG_ID,
+            program_id: crate::CONFIG_ID,
             accounts,
             data,
         }
@@ -219,7 +219,7 @@ impl<'a, 'b> StoreCpi<'a, 'b> {
         data.append(&mut args);
 
         let instruction = solana_instruction::Instruction {
-            program_id: crate::SOLANA_CONFIG_ID,
+            program_id: crate::CONFIG_ID,
             accounts,
             data,
         };

--- a/clients/rust/src/generated/programs.rs
+++ b/clients/rust/src/generated/programs.rs
@@ -6,5 +6,5 @@
 
 use solana_address::{address, Address};
 
-/// `solana_config` program ID.
-pub const SOLANA_CONFIG_ID: Address = address!("Config1111111111111111111111111111111111111");
+/// `config` program ID.
+pub const CONFIG_ID: Address = address!("Config1111111111111111111111111111111111111");

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,6 +4,6 @@ mod generated;
 mod hooked;
 
 pub use {
-    generated::{programs::SOLANA_CONFIG_ID as ID, *},
+    generated::{programs::CONFIG_ID as ID, *},
     hooked::*,
 };

--- a/program/idl.json
+++ b/program/idl.json
@@ -134,7 +134,7 @@
       }
     ],
     "errors": [],
-    "name": "solanaConfig",
+    "name": "config",
     "prefix": "",
     "publicKey": "Config1111111111111111111111111111111111111",
     "version": "0.0.1",


### PR DESCRIPTION
Renames the `solanaConfig` program to `config` (dropping the redundant `solana` prefix, since the package is already namespaced) to align with the naming convention used across the other repos in the solana-program org. This is a breaking change to the public client API: `solanaConfigProgram()` → `configProgram()`, `SOLANA_CONFIG_PROGRAM_ADDRESS` → `CONFIG_PROGRAM_ADDRESS`, the `client.solanaConfig` namespace → `client.config`, and the Rust `SOLANA_CONFIG_ID` → `CONFIG_ID` (the `ID` re-export is unchanged).